### PR TITLE
Allow creation of multiple `Client`s, each with different options

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -21,7 +21,8 @@ var Client = function (resourceUrl, options) {
     throw new ArgumentError('Missing REST endpoint URL')
   }
 
-  this.options = extend(defaultOptions, options);
+  this.options = extend({}, defaultOptions);
+  this.options = extend(this.options, options);
   this.url = url.parse(resourceUrl);
 };
 


### PR DESCRIPTION
Currently, if you attempt to create two `Client` objects with different options, you'll overwrite the options of previously created `Client`s each time you create a new one:

```javascript
var RestClient = require('rest-facade').Client;
var options = { headers: { Authorization: 'Basic version1' } };
var Client1 = new RestClient('https://example.com/', options);
var Client2 = new RestClient('https://example.com/newFile', { headers: { Authorization: 'Basic 2'}});
```

This yields `Client1` as:

```javascript
{ options:
   { query: { convertCase: null, repeatParams: true },
     headers: { Authorization: 'Basic 2' } },
  url:
   Url {
     protocol: 'https:',
     slashes: true,
     auth: null,
     host: 'example.com',
     port: null,
     hostname: 'example.com',
     hash: null,
     search: null,
     query: null,
     pathname: '/',
     path: '/',
     href: 'https://example.com/' } }
```

and `Client2` as:

```javascript
{ options:
   { query: { convertCase: null, repeatParams: true },
     headers: { Authorization: 'Basic 2' } },
  url:
   Url {
     protocol: 'https:',
     slashes: true,
     auth: null,
     host: 'example.com',
     port: null,
     hostname: 'example.com',
     hash: null,
     search: null,
     query: null,
     pathname: '/newFile',
     path: '/newFile',
     href: 'https://example.com/newFile' } }
```

Notice that the `headers` parameter for both clients is now the same, and matches that of the second client.

This is caused by use of the `extend()` function supplied by NodeJS.

The `extend()` function mutates the object supplied by the first parameter, and then returns it (https://github.com/nodejs/node/blob/master/lib/util.js#L843-L853). This means that all instances of `Client` first add their own options to the global `defaultOptions` variable, before then using it.

Therefore all `Client` instances share the same options. This PR ensures that each instance of `Client` receives its own version of `options`, by first copying `defaultOptions` and then the supplied `options`.

I'm pretty sure that the existing behaviour isn't desirable, so hopefully this PR will result in the expected behaviour.