### PR TITLE
Check correct callback `arguments` index

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -195,7 +195,7 @@ Client.prototype.delete = function (/* [urlParams], [callback] */) {
     callback = arguments[1];
 
   // Signature delete(callback).
-  } else if (arguments.length === 1 && arguments[1] instanceof Function) {
+  } else if (arguments.length === 1 && arguments[0] instanceof Function) {
     callback = arguments[0];
 
   // Signature delete(urlParams).


### PR DESCRIPTION
The delete method is checking the wrong argument index for presence of a callback function in the case that there is only one argument given (I guess "everyone" uses the promise interface so this bug doesn't trigger)