### PR TITLE
implement pre-flight pre-request customization 

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Users.getAll(function (err, users) {
 
 All methods accept an object with URL params as first argument. The properties in this object will be used to format the URL as shown above. However, the properties defined in this object, but not in the endpoint URL, will be added as query string params.
 
+> N.B. any properties in a given `options` object whose values are Functions will be ignored with regard to generating the query string. 
+
 ~~~js
 var Users = new rest.Client('http://domain.com/users/:id');
 
@@ -204,3 +206,18 @@ client.create({ firstName: 'John', lastName: 'Doe' });
 ~~~
 
 The same way, all the responses from the server will converted to the specified case (camelCase in this example).
+
+### Per-Request Customization
+Sometimes you need to do some customization to each individual request that is sent to the consumed API, 
+a likely candidate is for adding request-specific headers.
+
+This can be done in two ways:
+
+- defining a function in global options under `options.request.customizer`    
+- passing in a options object to a method call that contains a "special" `_requestCustomizer` property (which should be a function as well!)
+
+You can define both, in which case both will be applied (in the order listed above).
+
+In each case the function is passed the `req` and `params` representing the API call in question.
+
+

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "bluebird": "^2.10.2",
     "change-case": "^2.3.0",
-    "superagent": "^3.5.2"
+    "superagent": "^3.5.2",
+    "deepmerge": "^1.5.1"
   }
 }

--- a/src/Client.js
+++ b/src/Client.js
@@ -290,7 +290,7 @@ Client.prototype.request = function (options, params, callback) {
     }
 
     if (isFunction(params._requestCustomizer)) {
-      params.customizeRequest(req, params);
+      params._requestCustomizer(req, params);
     }
 
     // Send the request.

--- a/src/Client.js
+++ b/src/Client.js
@@ -1,13 +1,15 @@
 var extend = require('util')._extend;
 var url = require('url');
 var changeCase = require('change-case');
+var deepmerge = require('deepmerge');
 
 var request = require('superagent');
 var Promise = require('bluebird');
 var ArgumentError = require('./exceptions').ArgumentError;
 var APIError = require('./exceptions').APIError;
 var defaultOptions = require('./defaultOptions');
-var goToPath = require('./utils');
+var goToPath = require('./utils').goToPath;
+var isFunction = require('./utils').isFunction;
 
 /**
  * @class
@@ -21,8 +23,8 @@ var Client = function (resourceUrl, options) {
     throw new ArgumentError('Missing REST endpoint URL')
   }
 
-  this.options = extend({}, defaultOptions);
-  this.options = extend(this.options, options);
+  this.options = deepmerge(defaultOptions, options || {}, true);
+
   this.url = url.parse(resourceUrl);
 };
 
@@ -234,14 +236,21 @@ Client.prototype.request = function (options, params, callback) {
   var convertCaseParams = paramsCase ? changeCase[paramsCase] : null;
   var convertCaseBody = bodyCase ? changeCase[bodyCase] : null;
   var convertCaseRes = responseCase ? changeCase[responseCase] : null;
+  var reqCustomizer = this.options.request.customizer;
   var newKey = null;
   var value = null;
 
   for (var prevKey in params) {
+    value = params[prevKey];
+
+    if (isFunction(value)) {
+      continue;
+    }
+
     // If the user specified a convertion case (e.g. 'snakeCase') convert the
     // query string params names to the given case.
     newKey = convertCaseParams ? convertCaseParams(prevKey) : prevKey;
-    value = params[prevKey];
+
 
     // If the repeatParams flag is set to false, encode arrays in
     // the querystring as comma separated values.
@@ -275,6 +284,14 @@ Client.prototype.request = function (options, params, callback) {
 
     // Add all the given parameters to the querystring.
     req = req.query(queryParams);
+
+    if (isFunction(reqCustomizer)) {
+      reqCustomizer(req, params);
+    }
+
+    if (isFunction(params._requestCustomizer)) {
+      params.customizeRequest(req, params);
+    }
 
     // Send the request.
     req

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -5,6 +5,9 @@ module.exports = {
   },
 
   request: {
+    // optional function, will be called per backend request (prior to the call being made)
+    // with the the `req` and the `params` as arguments
+    customizer: null,
     body: {
       convertCase: null
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
-var objectProto = Object.prototype
-var hasOwnProperty = objectProto.hasOwnProperty
-var toString = objectProto.toString
-var symToStringTag = typeof Symbol != 'undefined' ? Symbol.toStringTag : undefined
+var objectProto = Object.prototype;
+var hasOwnProperty = objectProto.hasOwnProperty;
+var toString = objectProto.toString;
+var symToStringTag = typeof Symbol != 'undefined' ? Symbol.toStringTag : undefined;
 
 /*
 * Auxiliar function for get the error attributes
@@ -38,29 +38,29 @@ function goToPath(path, obj) {
  */
 function baseGetTag(value) {
   if (value == null) {
-    return value === undefined ? '[object Undefined]' : '[object Null]'
+    return value === undefined ? '[object Undefined]' : '[object Null]';
   }
   if (!(symToStringTag && symToStringTag in Object(value))) {
-    return toString.call(value)
+    return toString.call(value);
   }
-  var isOwn = hasOwnProperty.call(value, symToStringTag)
-  var tag = value[symToStringTag]
-  var unmasked = false
+  var isOwn = hasOwnProperty.call(value, symToStringTag);
+  var tag = value[symToStringTag];
+  var unmasked = false;
 
   try {
-    value[symToStringTag] = undefined
-    unmasked = true
+    value[symToStringTag] = undefined;
+    unmasked = true;
   } catch (e) {}
 
-  const result = toString.call(value)
+  const result = toString.call(value);
   if (unmasked) {
     if (isOwn) {
-      value[symToStringTag] = tag
+      value[symToStringTag] = tag;
     } else {
-      delete value[symToStringTag]
+      delete value[symToStringTag];
     }
   }
-  return result
+  return result;
 }
 
 function isObject(value) {
@@ -71,7 +71,7 @@ function isObject(value) {
 
 function isFunction(value) {
   if (!isObject(value)) {
-    return false
+    return false;
   }
 
   var tag = baseGetTag(value);

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,7 +52,7 @@ function baseGetTag(value) {
     unmasked = true;
   } catch (e) {}
 
-  const result = toString.call(value);
+  var result = toString.call(value);
   if (unmasked) {
     if (isOwn) {
       value[symToStringTag] = tag;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,13 @@
+var objectProto = Object.prototype
+var hasOwnProperty = objectProto.hasOwnProperty
+var toString = objectProto.toString
+var symToStringTag = typeof Symbol != 'undefined' ? Symbol.toStringTag : undefined
+
 /*
 * Auxiliar function for get the error attributes
 * from the given path.
 */
-module.exports = function goToPath(path, obj) {
+function goToPath(path, obj) {
   var current = obj;
   var keys = path.split('.');
   var currentKey;
@@ -14,4 +19,69 @@ module.exports = function goToPath(path, obj) {
       }
   }
   return current;
+};
+
+
+/**
+ * N.B. baseGetTag(), isObject() & isFunction() are lifted straight out of Lodash,
+ * with a little tweaking to conform to the coding standards in this project
+ *
+ * Lodash is awesome but I did not want add an extra dependency to this project!
+ */
+
+/**
+ * The base implementation of `getTag` without fallbacks for buggy environments.
+ *
+ * @private
+ * @param {*} value The value to query.
+ * @returns {string} Returns the `toStringTag`.
+ */
+function baseGetTag(value) {
+  if (value == null) {
+    return value === undefined ? '[object Undefined]' : '[object Null]'
+  }
+  if (!(symToStringTag && symToStringTag in Object(value))) {
+    return toString.call(value)
+  }
+  var isOwn = hasOwnProperty.call(value, symToStringTag)
+  var tag = value[symToStringTag]
+  var unmasked = false
+
+  try {
+    value[symToStringTag] = undefined
+    unmasked = true
+  } catch (e) {}
+
+  const result = toString.call(value)
+  if (unmasked) {
+    if (isOwn) {
+      value[symToStringTag] = tag
+    } else {
+      delete value[symToStringTag]
+    }
+  }
+  return result
+}
+
+function isObject(value) {
+  var type = typeof value;
+
+  return value != null && (type == 'object' || type == 'function');
+}
+
+function isFunction(value) {
+  if (!isObject(value)) {
+    return false
+  }
+
+  var tag = baseGetTag(value);
+
+  return tag == '[object Function]' || tag == '[object AsyncFunction]' ||
+    tag == '[object GeneratorFunction]' || tag == '[object Proxy]';
+}
+
+module.exports = {
+  goToPath : goToPath,
+  isObject : isObject,
+  isFunction : isFunction
 };

--- a/tests/client.tests.js
+++ b/tests/client.tests.js
@@ -600,7 +600,38 @@ module.exports = {
               expect(data.lastName).to.equal('Doe');
               done();
             });
-        }
+        },
+
+      'should allow for a request customizer, that is called for each request, in constructor options':
+        function (done) {
+
+          var options = { request: { customizer : function(req, params) {
+            req.send({alias: 'John Doe'});
+          } }};
+
+          var expected = { first_name: 'Kevin', last_name: 'Spacey', alias: 'John Doe' };
+          var client = this.client = new Client(domain + endpoint, options);
+          var request = nock(domain).post(endpoint, expected).reply(200);
+
+          client.create({ first_name: 'Kevin', last_name: 'Spacey' }, function (err) {
+            expect(request.isDone()).to.be.true;
+            done();
+          });
+        },
+
+      'should call a request customizer function given in params':
+        function (done) {
+          var expected = { first_name: 'John', last_name: 'Doe' };
+          var client = this.client = new Client(domain + endpoint);
+          var request = nock(domain, { reqheaders: { 'X-Fake': '1' } }).post(endpoint, expected).reply(200);
+
+          var reqfn = function(req, params) { req.header('X-Fake', '1'); };
+
+          client.create({ first_name: 'John', last_name: 'Doe', _requestCustomizer : reqfn }, function (err) {
+            expect(request.isDone()).to.be.true;
+            done();
+          });
+        },
     }
   }
 };

--- a/tests/client.tests.js
+++ b/tests/client.tests.js
@@ -623,11 +623,13 @@ module.exports = {
         function (done) {
           var expected = { first_name: 'John', last_name: 'Doe' };
           var client = this.client = new Client(domain + endpoint);
-          var request = nock(domain, { reqheaders: { 'X-Fake': '1' } }).post(endpoint, expected).reply(200);
+          var request = nock(domain, { reqheaders : {
+              'X-Fake': '1'
+          } }).post(endpoint, expected).reply(200);
 
-          var reqfn = function(req, params) { req.header('X-Fake', '1'); };
+          var reqfn = function(req, params) { req.set('X-Fake', '1'); };
 
-          client.create({ first_name: 'John', last_name: 'Doe', _requestCustomizer : reqfn }, function (err) {
+          client.create({_requestCustomizer : reqfn}, { first_name: 'John', last_name: 'Doe' }, function (err) {
             expect(request.isDone()).to.be.true;
             done();
           });


### PR DESCRIPTION
#Primary Goal

This PR is designed to allows specifying a customizer function in Client constructor options or in the params object of an individual call that allows for customizing individual requests.

> I've added couple of tests & a small section to the README

# Why?

because I need to send custom headers (e.g. "Authentication") that change dependent on the context of the caller (in this case a frontend `express` request).

# Auxillary change

The options object given to the Client constructor is now "deep merged" with the internal default options object to ensure that nested default object properties are not destroyed when passing in an options object that contains only a subset of nested options.

# Code examples

### e.g. in the constuctor options
```js
new Client(endpoint, { request : { customizer : function(req, params) { /* magic here */ } }})
```

### e.g. in the constuctor options
```js
var c = new Client(endpoint)

c.create({ title: foo, _requestCustomizer : function(req, params) { /* magic here */ } } })
```

