### PR TITLE
make errors more useful

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -309,6 +309,7 @@ Client.prototype.request = function (options, params, callback) {
       .set('Accept', 'application/json')
       .end(function (err, res) {
         if (err) {
+          var reqinfo = { method : method, url : options.url };
           var response = err.response || {};
           var data = response.body;
           var status = err.status;
@@ -318,9 +319,9 @@ Client.prototype.request = function (options, params, callback) {
               errorFormatter.hasOwnProperty('message')) {
              var name = goToPath(errorFormatter.name, data);
              var message = data ? goToPath(errorFormatter.message, data) : err.message;
-             error = new APIError(name, message, status, err);
+             error = new APIError(name, message, status, reqinfo, err);
           } else {
-            error = new APIError('APIError', data ? JSON.stringify(data) : err.message, status, err);
+            error = new APIError('APIError', data ? JSON.stringify(data) : err.message, status, reqinfo, err);
           }
 
           return reject(error);

--- a/src/Client.js
+++ b/src/Client.js
@@ -310,17 +310,17 @@ Client.prototype.request = function (options, params, callback) {
       .end(function (err, res) {
         if (err) {
           var response = err.response || {};
-          var data = response.body || {};
+          var data = response.body;
           var status = err.status;
           var error;
 
           if (errorFormatter && errorFormatter.hasOwnProperty('name') &&
               errorFormatter.hasOwnProperty('message')) {
              var name = goToPath(errorFormatter.name, data);
-             var message = goToPath(errorFormatter.message, data);
-             error = new APIError(name, message, status);
+             var message = data ? goToPath(errorFormatter.message, data) : err.message;
+             error = new APIError(name, message, status, err);
           } else {
-            error = new APIError('APIError', JSON.stringify(data), status);
+            error = new APIError('APIError', data ? JSON.stringify(data) : err.message, status, err);
           }
 
           return reject(error);

--- a/src/exceptions/APIError.js
+++ b/src/exceptions/APIError.js
@@ -1,10 +1,11 @@
 var util = require('util');
 
 
-var APIError = function(name, message, status, originalError){
+var APIError = function(name, message, status, requestInfo, originalError){
   this.name = name || this.constructor.name || this.constructor.prototype.name || '';
   this.message = message || '';
   this.statusCode = status || (originalError && originalError.code);
+  this.requestInfo = Object.assign({}, requestInfo);
   this.originalError = originalError;
 
   Error.captureStackTrace(this, this.constructor);

--- a/src/exceptions/APIError.js
+++ b/src/exceptions/APIError.js
@@ -1,10 +1,11 @@
 var util = require('util');
 
 
-var APIError = function(name, message, status){
-  this.name = name || '';
+var APIError = function(name, message, status, originalError){
+  this.name = name || this.constructor.name || this.constructor.prototype.name || '';
   this.message = message || '';
-  this.statusCode = status;
+  this.statusCode = status || (originalError && originalError.code);
+  this.originalError = originalError;
 
   Error.captureStackTrace(this, this.constructor);
 };

--- a/tests/exceptions.tests.js
+++ b/tests/exceptions.tests.js
@@ -44,7 +44,9 @@ module.exports = {
   'APIError': {
     '#constructor': {
       beforeEach: function() {
-        this.error = new APIError('Unauthorized', 'Invalid token', 401);
+        this.origError = new Error();
+        this.reqinfo = { method : 'post', url : '/some/endpoint' };
+        this.error = new APIError('Unauthorized', 'Invalid token', 401, this.reqinfo, this.origError);
       },
 
       'should be an instance of the builtin Error':
@@ -72,12 +74,23 @@ module.exports = {
           expect(this.error.statusCode).to.eql(401);
         },
 
+      'should have request info':
+        function () {
+          expect((this.error.requestInfo || {}).method).to.eql(this.reqinfo.method);
+          expect((this.error.requestInfo || {}).url).to.eql(this.reqinfo.url);
+        },
+
+      'should have an original error':
+        function () {
+          expect(this.error.originalError).to.eql(this.origError);
+        },
+
       'should have a stack with the message and location the error was created':
         function () {
           expect(this.error.stack).to.exist;
           var stackLines = this.error.stack.split('\n');
           expect(stackLines[0]).to.eql('Unauthorized: Invalid token');
-          expect(stackLines[1]).to.include('tests/exceptions.tests.js:47');
+          expect(stackLines[1]).to.include(__filename);
         }
     }
   }


### PR DESCRIPTION
hi,

the `APIError` creation logic makes assumptions about the underlying error which are not always helpful, most specifically in the case where the facade cannot access the HTTP service that is being "wrapped", in my particular case I was testing what happens if my underlying API service crashes, in such a case the underlying error looks like so:

```js
{ Error: connect ECONNREFUSED 127.0.0.1:42004
       at Object.exports._errnoException (util.js:1007:11)
       at exports._exceptionWithHostPort (util.js:1030:20)
       at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1080:14)
     code: 'ECONNREFUSED',
     errno: 'ECONNREFUSED',
     syscall: 'connect',
     address: '127.0.0.1',
     port: 42004,
     response: undefined } }
```

but the exposed API error contains none of that information (the "`ECONNREFUSED`" is the important fact that should be exposed.), the `APIError` has no status code  and a message of "{}" (it's stack trace only hints at the cause)

This PR does the following: 

1. changes the logic for `APIError` creation so that the `message` is taken/extracted from the underlying error if no other message value can be determined.
2. changes the logic for `APIError` creation so that a fourth constructor parameter is passed in that - this parameter is the underlying error instance, which is added to the `APIError` under teh property `originalError`
3. changes the `APIError` constructor logic to use the value of `originalError.code` as the value of it's  `status` property if the given `statusCode` constructor parameter is "FALSEY" 

> **aside**: the use and behaviour of the `errorFormatter` option is undocumented, which of itself is a little unhelpful ... but more importantly it's usage also make the same assumptions with regard to the underlying error. 