### PR TITLE
gzip DoS on superagent

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bluebird": "^2.10.2",
     "change-case": "^2.3.0",
     "deepmerge": "^1.5.1",
-    "superagent": "^3.5.2",
+    "superagent": "^3.8.0",
     "superagent-proxy": "^1.0.2"
   }
 }


### PR DESCRIPTION
There is a security report about `superagent` being susceptible to a DoS attack. Upgrading to >= 3.7.0 is a recommended fix.

https://nodesecurity.io/advisories/479