### PR TITLE
make APIError argument generation/extraction more flexible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -187,7 +187,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
       "dev": true
     },
     "component-emitter": {
@@ -256,7 +256,7 @@
     "data-uri-to-buffer": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
-      "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
+      "integrity": "sha1-dxY+qcINhkG0cH6PGKvfmnjzSDU="
     },
     "debug": {
       "version": "2.6.8",
@@ -297,7 +297,7 @@
     "deepmerge": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.1.tgz",
-      "integrity": "sha512-Ndl8eeOHB9dQkmT1HWCgY3t0odl4bmWKFzjQZBYAxVTNs2B3nn5b6orimRYHKZ4FI8psvZkA1INRCW6l7vc9lQ=="
+      "integrity": "sha1-wFO/Bv1ydvGZT3DAmgdgy2GlYjc="
     },
     "degenerator": {
       "version": "1.0.4",
@@ -346,7 +346,7 @@
     "es6-promise": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
+      "integrity": "sha1-iBHpCRXZoNujYnTwskLb2nj5ySo="
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -415,7 +415,7 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -487,7 +487,7 @@
     "get-uri": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.1.tgz",
-      "integrity": "sha512-7aelVrYqCLuVjq2kEKRTH8fXPTC0xKTkM+G7UlFkEwCXY3sFbSxvY375JoFowOAYbkaU47SrBvOefUlLZZ+6QA==",
+      "integrity": "sha1-29ysrNjGCKODFoaTaBF2l6FjHFk=",
       "requires": {
         "data-uri-to-buffer": "1.2.0",
         "debug": "2.6.8",
@@ -614,7 +614,7 @@
     "iconv-lite": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
+      "integrity": "sha1-I9hlaxaq5nQqwpcy6o8DNqR4nPI="
     },
     "inherits": {
       "version": "2.0.3",
@@ -785,6 +785,11 @@
       "integrity": "sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "log-driver": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
@@ -821,9 +826,9 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "mime": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-      "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
       "version": "1.29.0",
@@ -987,7 +992,7 @@
     "pac-proxy-agent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-2.0.0.tgz",
-      "integrity": "sha512-t57UiJpi5mFLTvjheC1SNSwIhml3+ElNOj69iRrydtQXZJr8VIFYSDtyPi/3ZysA62kD2dmww6pDlzk0VaONZg==",
+      "integrity": "sha1-vrF80rBqILN51X4bLiwpvg3+X5o=",
       "requires": {
         "agent-base": "2.1.1",
         "debug": "2.6.8",
@@ -1002,7 +1007,7 @@
         "socks-proxy-agent": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.0.tgz",
-          "integrity": "sha512-YJcT+SNNBgFoK/NpO20PChz0VnBOhkjG3X10BwlrYujd0NZlSsH1jbxSQ1S0njt3sOvzwQ2PvGqqUIvP4rNk/w==",
+          "integrity": "sha1-6iMIXNK96U0ISmJEjzETnKftYkU=",
           "requires": {
             "agent-base": "4.1.1",
             "socks": "1.1.10"
@@ -1011,7 +1016,7 @@
             "agent-base": {
               "version": "4.1.1",
               "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.1.tgz",
-              "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
+              "integrity": "sha1-ktik/CUko7CbNmajO2yXlg8j1qQ=",
               "requires": {
                 "es6-promisify": "5.0.0"
               }
@@ -1023,7 +1028,7 @@
     "pac-resolver": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
-      "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+      "integrity": "sha1-auoweH2wqJFwTet4AKcip2FabyY=",
       "requires": {
         "co": "4.6.0",
         "degenerator": "1.0.4",
@@ -1091,7 +1096,7 @@
     "proxy-agent": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-I23qaUnXmU/ItpXWQcMj9wMcZQTXnJNI7nakSR+q95Iht8H0+w3dCgTJdfnOQqOCX1FZwKLSgurCyEt11LM6OA==",
+      "integrity": "sha1-o6Kzhm3r/rebt5HzRdybyHbn/4Y=",
       "requires": {
         "agent-base": "2.1.1",
         "debug": "2.6.8",
@@ -1110,9 +1115,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-      "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "raw-body": {
       "version": "2.3.0",
@@ -1128,7 +1133,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -1204,7 +1209,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "samsam": {
       "version": "1.1.2",
@@ -1282,7 +1287,7 @@
     "socks-proxy-agent": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-2.1.1.tgz",
-      "integrity": "sha512-sFtmYqdUK5dAMh85H0LEVFUCO7OhJJe1/z2x/Z6mxp3s7/QPf1RkZmpZy+BpuU0bEjcV9npqKjq9Y3kwFUjnxw==",
+      "integrity": "sha1-huuwcZMlhjeHDhO3vZnybGY989M=",
       "requires": {
         "agent-base": "2.1.1",
         "extend": "3.0.1",
@@ -1354,20 +1359,30 @@
       }
     },
     "superagent": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.6.0.tgz",
-      "integrity": "sha512-oWsu4mboo8sVxagp4bNwZIR1rUmypeAJDmNIwT9mF4k06hSu6P92aOjEWLaIj7vsX3fOUp+cRH/04tao+q5Q7A==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.0.tgz",
+      "integrity": "sha512-71XGWgtn70TNwgmgYa69dPOYg55aU9FCahjUNY03rOrKvaTCaU3b9MeZmqonmf9Od96SCxr3vGfEAnhM7dtxCw==",
       "requires": {
         "component-emitter": "1.2.1",
         "cookiejar": "2.1.1",
-        "debug": "2.6.8",
+        "debug": "3.1.0",
         "extend": "3.0.1",
         "form-data": "2.3.1",
         "formidable": "1.1.1",
         "methods": "1.1.2",
-        "mime": "1.3.6",
-        "qs": "6.5.0",
+        "mime": "1.4.1",
+        "qs": "6.5.1",
         "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "superagent-proxy": {
@@ -1493,7 +1508,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
       "dev": true
     },
     "verror": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "bluebird": "^2.10.2",
     "change-case": "^2.3.0",
     "deepmerge": "^1.5.1",
+    "lodash.get": "^4.4.2",
     "superagent": "^3.8.0",
     "superagent-proxy": "^1.0.2"
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,7 +30,7 @@ function resolveAPIErrorArg(formatter, data, defaults)
         val = formatter(data);
         break;
       case 'string':
-        val = get(formatter, data);
+        val = get(data, formatter);
         break;
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,24 +3,47 @@ var hasOwnProperty = objectProto.hasOwnProperty;
 var toString = objectProto.toString;
 var symToStringTag = typeof Symbol != 'undefined' ? Symbol.toStringTag : undefined;
 
+var get = require('lodash.get');
+
 /*
-* Auxiliar function for get the error attributes
-* from the given path.
+* Auxiliar function for extracting an APIError argument from the
+* given `data` using the given "formatter"
+*
+* @param {String|Function|undefined)  formatter  - either a string used to "get" the property-path,
+*                                                  or a custom function (data is passed to it)
+* @param {Object|null}                data       - a data object, assumed to be the response body
+* @param {mixed|Array[mixed])         defaults   - a default value, or an array of defaults values.
+*                                                  used if no value could be extracted from `data` using the `formatter`
+*                                                  (e.g. if data is empty or the formatter is undefined),
+*                                                  in the case of multiple defaults the first TRUTHY value is used.
+*
+* @return {String}
 */
-function goToPath(path, obj) {
-  var current = obj;
-  var keys = path.split('.');
-  var currentKey;
+function resolveAPIErrorArg(formatter, data, defaults)
+{
+  var val, def;
+  var defs = Array.isArray(defaults) ? defaults : [defaults];
 
-  while (currentKey = keys.shift()) {
-    if (typeof current === 'object' &&
-      current.hasOwnProperty(currentKey)) {
-        current = current[currentKey];
-      }
+  if (formatter && data) {
+    switch (typeof formatter) {
+      case 'function':
+        val = formatter(data);
+        break;
+      case 'string':
+        val = get(formatter, data);
+        break;
+    }
   }
-  return current;
-};
 
+  while (!val && defs.length) {
+    val = defs.shift();
+  }
+
+  if (val && (typeof val === 'object'))
+    val = JSON.stringify(val);
+
+  return (val || '') + '';
+}
 
 /**
  * N.B. baseGetTag(), isObject() & isFunction() are lifted straight out of Lodash,
@@ -81,7 +104,7 @@ function isFunction(value) {
 }
 
 module.exports = {
-  goToPath : goToPath,
+  resolveAPIErrorArg : resolveAPIErrorArg,
   isObject : isObject,
   isFunction : isFunction
 };

--- a/tests/utils.tests.js
+++ b/tests/utils.tests.js
@@ -1,0 +1,65 @@
+var expect = require('chai').expect;
+var utils = require('../src/utils');
+
+
+module.exports = {
+  'Utils': {
+    'isObject': {
+      'should be a function':
+        function () {
+          expect(utils.isObject).to.be.a('function');
+        },
+
+      'should return TRUE for object arguments':
+        function () {
+          expect(utils.isObject({})).to.be.true;
+          expect(utils.isObject(function() {})).to.be.true;
+          expect(utils.isObject([])).to.be.true;
+        },
+
+      'should return FALSE for non-object arguments':
+        function () {
+          expect(utils.isObject(null)).to.be.false;
+          expect(utils.isObject(false)).to.be.false;
+          expect(utils.isObject('hello')).to.be.false;
+        },
+    },
+
+    'isFunction': {
+      'should be a function':
+        function () {
+          expect(utils.isFunction).to.be.a('function');
+        },
+
+      'should return TRUE for function arguments':
+        function () {
+          expect(utils.isFunction(function() {})).to.be.true;
+        },
+
+      'should return FALSE for non-function arguments':
+        function () {
+          expect(utils.isFunction({})).to.be.false;
+          expect(utils.isFunction(null)).to.be.false;
+          expect(utils.isFunction(false)).to.be.false;
+          expect(utils.isFunction(true)).to.be.false;
+          expect(utils.isFunction([])).to.be.false;
+          expect(utils.isFunction('hello')).to.be.false;
+        },
+    },
+
+    'resolveAPIErrorArg': {
+      'should be a function':
+        function () {
+          expect(utils.resolveAPIErrorArg).to.be.a('function');
+        },
+
+      'should return expected string values':
+        function () {
+          expect(utils.resolveAPIErrorArg('abc.def.0.g', {abc:{def:[{g:true}]}}, 'default!')).to.equal('true');
+          expect(utils.resolveAPIErrorArg('abc.def.0.g', {abc:{def:[{g:null}]}}, 'default!')).to.equal('default!');
+          expect(utils.resolveAPIErrorArg(function(d) { return d && d.a; }, {a:"hello"}, [null, "default!"])).to.equal('hello');
+          expect(utils.resolveAPIErrorArg(function(d) { return d && d.b; }, {a:"hello"}, [null, "default!"])).to.equal('default!');
+        },
+    }
+  }
+};


### PR DESCRIPTION
this PR builds on #23, it replaces the `goToPath` util function with one called `resolveAPIErrorArg`, tests are included.

an example of `resolveAPIErrorArg` usage (the function is used in only a single place in the code, where previously `goToPath` was used):

```js
var resolveAPIErrorArg = require('./utils');

resolveAPIErrorArg('abc.def.0.g', {abc:{def:[{g:true}]}}, "default!"); // returns "true"
resolveAPIErrorArg('abc.def.0.g', {abc:{def:[{g:null}]}}, "default!"); // returns "default!"
resolveAPIErrorArg(function(d) { return d && d.a; }, {a:"hello"}, [null, "default!"]); // returns "hello"
resolveAPIErrorArg(function(d) { return false; }, {}, [null, "default!"]); // returns "default!"
```

the goal is to make generation of values for the `APIError` `name` & `message` arguments a little more flexible and improve the fallback/default-value behavior with regard to resolving the aforementioned values.

`resolveAPIErrorArg` makes use of the optional `errorFormatter.name` and `errorFormatter.message` contructor options. before these could only be strings, now they can also be functions. 

## when the formatter is a string.
it works in the same way as the previous `goToPath` functionality, which the exception that retrieving values in (possibly) nested arrays is also supported - I opted to include the package `lodash.get` in order to implement this (I did not think copying/pasting all the pre-requisite code was a good idea). the reason for using `lodash.get` in place of the `goToPath`

## when the formatter is a function.
the function is called with the given data and the return value is used as the resolved value.

## default values
if no valid formatter is given/set or if the formatter did not resolve to a truthy value then the default value is used - in the case that the default value is an array then the first truthy value in the array is used.

## return values
the returned value is always a string, either empty (if no truthy value could be determined) or a string representation of the resolved value (if the value is an object then it is `JSON.stringify`d as per [the current behaviour found at Client.js#L324](https://github.com/OOShoppingnl/rest-facade/blob/874b0ad66dcb996b2bfdea00087640e3e1e33a34/src/Client.js#L324))
