### PR TITLE
make rest-facade accept string request bodies

### DIFF
--- a/tests/client.tests.js
+++ b/tests/client.tests.js
@@ -248,10 +248,10 @@ module.exports = {
           expect(this.client.post).to.be.an.instanceOf(Function);
         },
 
-      'should require a data object as first argument':
+      'should require a data object or string as first argument':
         function () {
           expect(this.client.post)
-            .to.throw(ArgumentError, 'Missing data object');
+            .to.throw(ArgumentError, 'Missing/invalid request body data');
         },
 
       'should allow a callback as second argument':
@@ -353,11 +353,11 @@ module.exports = {
           });
         },
 
-      'should require an object as second argument':
+      'should require an object or string as second argument':
         function () {
           var updateWithoutData = this.client.patch.bind(this.client, { id: this.id });
 
-          expect(updateWithoutData).to.throw(ArgumentError, 'The data must be an object');
+          expect(updateWithoutData).to.throw(ArgumentError, 'Missing/invalid request body data');
         },
 
       'should perform a PATCH /endpoint/:id':
@@ -449,11 +449,11 @@ module.exports = {
           });
         },
 
-      'should require an object as second argument':
+      'should require an object or string as second argument':
         function () {
           var updateWithoutData = this.client.put.bind(this.client, { id: this.id });
 
-          expect(updateWithoutData).to.throw(ArgumentError, 'The data must be an object');
+          expect(updateWithoutData).to.throw(ArgumentError, 'Missing/invalid request body data');
         },
 
       'should perform a PUT /endpoint/:id':


### PR DESCRIPTION
this is an initial attempt to make rest-facade capable of accepting string request bodies (in relation to issue #35).

questions:

1. do you want this?
2. does anything else need to be done to make it work (and/or backwards compatible)? (e.g. add a `req.type('json')` call to force the request content to 'application/json')
3. what kind of documentation is needed? (there are undoubtly some caveats related to passing in strings instead of objects as request bodies)
