### PR TITLE
Allow for custom error handlers

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -268,6 +268,7 @@ Client.prototype.delete = function (/* [urlParams], [callback] */) {
 Client.prototype.request = function (options, params, callback) {
   var headers = this.options.headers || {};
   var errorFormatter = this.options.errorFormatter || {};
+  var errorConstructor = this.options.errorCustomizer || APIError;
   var paramsCase = this.options.query.convertCase;
   var bodyCase = this.options.request.body.convertCase;
   var responseCase = this.options.response.body.convertCase;
@@ -338,7 +339,7 @@ Client.prototype.request = function (options, params, callback) {
       } else {
         // if no callback (run synchronously)
         reqCustomizer(req, params);
-        runParamsRequestCustomizer();  
+        runParamsRequestCustomizer();
       }
     } else {
       runParamsRequestCustomizer();
@@ -383,7 +384,7 @@ Client.prototype.request = function (options, params, callback) {
             var name = resolveAPIErrorArg(errorFormatter.name, data, 'APIError');
             var message = resolveAPIErrorArg(errorFormatter.message, data, [data, err.message]);
   
-            return reject(new APIError(name, message, status, reqinfo, err))
+            return reject(new errorConstructor(name, message, status, reqinfo, err));
           }
 
           // If case conversion is enabled for the body of the response, convert

--- a/tests/client.tests.js
+++ b/tests/client.tests.js
@@ -642,6 +642,32 @@ module.exports = {
           });
         },
 
+        'should allow for an error customizer, that is called for each request, in constructor options':
+          function (done) {
+            nock.cleanAll();
+
+            var options = {
+              errorCustomizer: function(name, message, status, requestInfo, originalError){
+                this.name = name;
+                this.message = message;
+                this.statusCode = status;
+                this.requestInfo = requestInfo;
+                this.originalError = originalError;
+              }
+            };
+
+            var client = this.client = new Client(domain + endpoint, options);
+            var req = nock(domain).post(endpoint).replyWithError();
+
+            client
+            .get()
+            .catch(function (err) {
+              expect(err).to.exist;
+              expect(err).to.be.an.instanceOf(options.errorCustomizer);
+              done();
+            });
+          },
+
       'should allow for an asynchronous request customizer, that is called for each request, in constructor options':
         function (done) {
 


### PR DESCRIPTION
This allows for implementing custom error handlers.  Passing an error constructor to `errorCustomizer` will override the default `ApiError` constructor.