### PR TITLE
feat: add support to persistent connections (keep alive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,3 +293,13 @@ var client = new rest.Client(url, {
   proxy: 'https://myproxy.com:1234'
 });
 ```
+
+### Persistent Connections (Keep-alive)
+
+By default, persistent connection are not enabled. To enabled it, use the option:
+
+```js
+var client = new rest.Client(url, {
+  keepAlive: true
+});
+```

--- a/src/Client.js
+++ b/src/Client.js
@@ -14,6 +14,12 @@ var isFunction = require('./utils').isFunction;
 // Add proxy support to the request library.
 require('superagent-proxy')(request);
 
+const HttpsAgent = require('https').Agent;
+const keepAliveAgent = new HttpsAgent({
+  keepAlive: true,
+});
+
+
 /**
  * @class
  * Facade pattern for REST API endpoint consumption.
@@ -280,6 +286,7 @@ Client.prototype.request = function (options, params, callback) {
   var proxy = this.options.proxy;
   var newKey = null;
   var value = null;
+  var useKeepAlive = this.options.keepAlive;
 
   for (var prevKey in params) {
     value = params[prevKey];
@@ -320,6 +327,10 @@ Client.prototype.request = function (options, params, callback) {
 
     if (proxy) {
       req = req.proxy(proxy);
+    }
+
+    if (useKeepAlive) {
+      req = req.agent(keepAliveAgent);
     }
 
     req = req.send(options.data);
@@ -380,10 +391,10 @@ Client.prototype.request = function (options, params, callback) {
             var data = response.body;
             var status = err.status;
             var error;
-  
+
             var name = resolveAPIErrorArg(errorFormatter.name, data, 'APIError');
             var message = resolveAPIErrorArg(errorFormatter.message, data, [data, err.message]);
-  
+
             return reject(new errorConstructor(name, message, status, reqinfo, err));
           }
 

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -18,7 +18,7 @@ module.exports = {
       convertCase: null
     }
   },
-
-  proxy: null
+  proxy: null,
+  keepAlive: false,
 };
 

--- a/tests/client.tests.js
+++ b/tests/client.tests.js
@@ -744,6 +744,23 @@ module.exports = {
               done();
             });
         },
+
+      'should use persistent connections when it is enabled on the constructor options':
+        function (done) {
+          var options = { keepAlive: true };
+          var client = this.client = new Client(domain + endpoint, options);
+          var nockRequest = nock(domain)
+            .get(endpoint)
+            .reply(200);
+          sinon.spy(request.Request.prototype, 'agent');
+          client
+            .get()
+            .then(function() {
+              expect(request.Request.prototype.agent.calledOnce).to.be.true;
+              expect(nockRequest.isDone()).to.be.true;
+              done();
+            });
+        },
     }
   }
 };


### PR DESCRIPTION
- add new client option to enable keep alive;
- if the option is present, use another agent with the keep alive enabled;

I've done a quick benchmark to compare using and not using persistent connections:

```
var rest = require('./index');

function runBenchmark(options) {
  var client = new rest.Client('https://google.com', options);
  console.time(`test`);
  return client.getAll()
    .then(() => client.getAll())
    .then(() => client.getAll())
    .then(() => client.getAll())
    .then(() => client.getAll())
    .then(() => client.getAll())
    .then(() => console.timeEnd('test'));
}

runBenchmark({})
  .then(() => runBenchmark({ keepAlive: true }));
```

Results in my machine (internet connection is not so fast):
```
test: 1941.420ms
test: 1277.164ms
```
