### PR TITLE
Moving super agent back to dependencies #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   "dependencies": {
     "change-case": "^2.3.0",
     "deepmerge": "^3.2.0",
-    "lodash.get": "^4.4.2"
-    "superagent": "^5.1.1",
+    "lodash.get": "^4.4.2",
+    "superagent": "^5.1.1"
   },
   "peerDependencies": {
     "superagent-proxy": "^3.0.0"


### PR DESCRIPTION
As the following module is throwing error on transitive packages i.e as auth0 requires react-facade its throwing error for requiring superagent so one quick solution might be to move that back to dependencies

issue https://github.com/ngonzalvez/rest-facade/issues/60