### PR TITLE
Delete duplicated require of superagent-proxy

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -11,9 +11,6 @@ var defaultOptions = require('./defaultOptions');
 var resolveAPIErrorArg = require('./utils').resolveAPIErrorArg;
 var isFunction = require('./utils').isFunction;
 
-// Add proxy support to the request library.
-require('superagent-proxy')(request);
-
 const HttpsAgent = require('https').Agent;
 const keepAliveAgent = new HttpsAgent({
   keepAlive: true,


### PR DESCRIPTION
I believe that the `require()` statement has been left in the header of the file, which causes the error `Cannot find module 'superagent-proxy'` in use.

Deleting the top level require should allow those who want to use a proxy to include superagent-proxy as per documentation, only when needed.