### PR TITLE
fix: add peerDependenciesMeta to package.json for superagent-proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,10 @@
   },
   "peerDependencies": {
     "superagent-proxy": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "superagent-proxy": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
Hi, thanks for the great work. We are using auh0 lib, and it depends on rest-facade, but doesn't use superagent-proxy. So it's better to mark the peerDependency optional.